### PR TITLE
Test contracts for procedures (#560)

### DIFF
--- a/misc/emacs-mode/scilla-mode.el
+++ b/misc/emacs-mode/scilla-mode.el
@@ -30,7 +30,7 @@
 
 (defvar scilla-keywords
   '("builtin" "library" "let" "in" "match" "with" "end" "event"
-    "fun" "tfun" "contract" "transition" "send" "field" "accept"
+    "fun" "tfun" "contract" "transition" "procedure" "send" "field" "accept"
     "Emp" "import" "type" "exists" "delete"))
 
 (defvar scilla-mode-syntax-table
@@ -67,7 +67,7 @@
 (setq default-tab-width 2)
 
 ;; Rule 1: Beginning of buffer: column 0
-;; Rule 2: Previous line contains "(let.*=|transition)"
+;; Rule 2: Previous line contains "(let.*=|transition|procedure)"
 ;;             indent forward
 ;; Rule 3: If previous line has "end|send": indent back
 ;; Rule 4: If line begins with "|", find matching "match" and indent to that.
@@ -77,7 +77,7 @@
 ;; Rule 6: If previous line contains "*=>[ \t]*$"
 ;;         but current line is not fun:
 ;;            indent forward.
-;; Rule 7: If line begins with "end", find matching "match/transition"
+;; Rule 7: If line begins with "end", find matching "match/transition/procedure"
 ;; Else: Same as previous line.
 
 (defun scilla-indent-line ()
@@ -119,7 +119,7 @@
                     (forward-line -1)
                     (setq lines-seen (+ lines-seen 1))
                     (if (looking-at "[ \t]*end") (setq ends-seen (+ ends-seen 1)))
-                    (if (looking-at "[ \t]*\\(match\\|transition\\)")(setq matches-seen (+ matches-seen 1)))
+                    (if (looking-at "[ \t]*\\(match\\|transition|procedure\\)")(setq matches-seen (+ matches-seen 1)))
                     ;; (message "Line %d: %d matches and %d ends seen" cur-line matches-seen ends-seen)
                     (if (> matches-seen ends-seen)
                         (progn
@@ -137,7 +137,7 @@
             )
           (forward-line -1)
           ;; Match Rule 2
-          (if (and (not indented) (looking-at "[ \t]*\\(transition\\|let.*=[ \t]*$\\)"))
+          (if (and (not indented) (looking-at "[ \t]*\\(transition\\|procedure\\|let.*=[ \t]*$\\)"))
               (progn
                 ;; (message "Line %d: rule 2 matched" cur-line)
                 (setq cur-indent (+ (current-indentation) default-tab-width))

--- a/src/lang/base/ScillaParser.mly
+++ b/src/lang/base/ScillaParser.mly
@@ -331,7 +331,7 @@ stmt:
   { (MatchStmt (Ident (x, toLoc $startpos(x)), cs), toLoc $startpos)  }
 | (* procedure call *)
   p = component_id;
-  args = nonempty_list(sident)
+  args = list(sident)
   { (CallProc (p, args), toLoc $startpos)  }
 
 stmt_pm_clause:

--- a/tests/checker/bad/TestCheckerFail.ml
+++ b/tests/checker/bad/TestCheckerFail.ml
@@ -66,6 +66,14 @@ module Tests = TestUtil.DiffBasedTests(
       "balance_field.scilla";
       "bad_param.scilla";
       "bad_transition_param.scilla";
+      "recursive_procedure.scilla";
+      "mutually_recursive_procedure.scilla";
+      "forward_definition_procedure.scilla";
+      "procedure_bad_type.scilla";
+      "procedure_bad_args.scilla";
+      "procedure_map_arg.scilla";
+      "name_clashes.scilla";
+      "procedure_env.scilla";
     ]
     let exit_code : Unix.process_status = WEXITED 1
   end)

--- a/tests/checker/bad/forward_definition_procedure.scilla
+++ b/tests/checker/bad/forward_definition_procedure.scilla
@@ -1,0 +1,24 @@
+scilla_version 0
+
+library MyLib
+
+contract ForwardDefinitionProcedure ()
+
+field tmp : Int32 = Int32 0
+
+procedure Proc1(arg : Int32)
+  new_arg = True;
+  (* Proc2 not in scope *)
+  Proc2 new_arg
+end
+
+procedure Proc2 (arg : Bool)
+  match arg with
+  | True =>
+    a = Int32 1;
+    tmp := a
+  | False =>
+    a = Int32 42;
+    tmp := a
+  end
+end

--- a/tests/checker/bad/gold/forward_definition_procedure.scilla.gold
+++ b/tests/checker/bad/gold/forward_definition_procedure.scilla.gold
@@ -1,0 +1,20 @@
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error(s) in contract ForwardDefinitionProcedure:\n",
+      "start_location": {
+        "file": "checker/bad/forward_definition_procedure.scilla",
+        "line": 5,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Procedure calls are not supported yet.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/checker/bad/gold/mutually_recursive_procedure.scilla.gold
+++ b/tests/checker/bad/gold/mutually_recursive_procedure.scilla.gold
@@ -1,0 +1,20 @@
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error(s) in contract MutuallyRecursiveProcedure:\n",
+      "start_location": {
+        "file": "checker/bad/mutually_recursive_procedure.scilla",
+        "line": 5,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Procedure calls are not supported yet.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/checker/bad/gold/name_clashes.scilla.gold
+++ b/tests/checker/bad/gold/name_clashes.scilla.gold
@@ -1,0 +1,49 @@
+{
+  "errors": [
+    {
+      "error_message": "Identifier Proc1 used more than once\n",
+      "start_location": {
+        "file": "checker/bad/name_clashes.scilla",
+        "line": 7,
+        "column": 11
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Identifier Proc2 used more than once\n",
+      "start_location": {
+        "file": "checker/bad/name_clashes.scilla",
+        "line": 17,
+        "column": 11
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Identifier Trans1 used more than once\n",
+      "start_location": {
+        "file": "checker/bad/name_clashes.scilla",
+        "line": 28,
+        "column": 12
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Identifier Trans2 used more than once\n",
+      "start_location": {
+        "file": "checker/bad/name_clashes.scilla",
+        "line": 38,
+        "column": 12
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": [
+    {
+      "warning_message":
+        "No transition in contract TransitionAndProcedureNameClashes contains an accept statement\n",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 },
+      "warning_id": 1
+    }
+  ]
+}

--- a/tests/checker/bad/gold/procedure_bad_args.scilla.gold
+++ b/tests/checker/bad/gold/procedure_bad_args.scilla.gold
@@ -1,0 +1,19 @@
+{
+  "errors": [
+    {
+      "error_message": "Type error(s) in contract ProcedureCallBadType:\n",
+      "start_location": {
+        "file": "checker/bad/procedure_bad_args.scilla",
+        "line": 5,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Procedure calls are not supported yet.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/checker/bad/gold/procedure_bad_type.scilla.gold
+++ b/tests/checker/bad/gold/procedure_bad_type.scilla.gold
@@ -1,0 +1,19 @@
+{
+  "errors": [
+    {
+      "error_message": "Type error(s) in contract ProcedureCallBadType:\n",
+      "start_location": {
+        "file": "checker/bad/procedure_bad_type.scilla",
+        "line": 5,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Procedure calls are not supported yet.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/checker/bad/gold/procedure_env.scilla.gold
+++ b/tests/checker/bad/gold/procedure_env.scilla.gold
@@ -1,0 +1,19 @@
+{
+  "errors": [
+    {
+      "error_message": "Type error(s) in contract ProcedureBadEnv:\n",
+      "start_location": {
+        "file": "checker/bad/procedure_env.scilla",
+        "line": 5,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Procedure calls are not supported yet.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/checker/bad/gold/procedure_map_arg.scilla.gold
+++ b/tests/checker/bad/gold/procedure_map_arg.scilla.gold
@@ -1,0 +1,19 @@
+{
+  "errors": [
+    {
+      "error_message": "Type error(s) in contract ProcedureCallBadType:\n",
+      "start_location": {
+        "file": "checker/bad/procedure_map_arg.scilla",
+        "line": 5,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Procedure calls are not supported yet.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/checker/bad/gold/recursive_procedure.scilla.gold
+++ b/tests/checker/bad/gold/recursive_procedure.scilla.gold
@@ -1,0 +1,19 @@
+{
+  "errors": [
+    {
+      "error_message": "Type error(s) in contract RecursiveProcedure:\n",
+      "start_location": {
+        "file": "checker/bad/recursive_procedure.scilla",
+        "line": 5,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Procedure calls are not supported yet.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/checker/bad/mutually_recursive_procedure.scilla
+++ b/tests/checker/bad/mutually_recursive_procedure.scilla
@@ -1,0 +1,17 @@
+scilla_version 0
+
+library MyLib
+
+contract MutuallyRecursiveProcedure ()
+
+procedure Proc1(arg : Int32)
+  new_arg = Int32 0;
+  (* Proc2 not in scope - mutually recursive procedures not allowed *)
+  Proc2 new_arg
+end
+
+procedure Proc2 (arg : Int32)
+  new_arg = Int32 0;
+  (* Allowed *)
+  Proc1 new_arg
+end

--- a/tests/checker/bad/name_clashes.scilla
+++ b/tests/checker/bad/name_clashes.scilla
@@ -1,0 +1,47 @@
+scilla_version 0
+
+library MyLib
+
+contract TransitionAndProcedureNameClashes ()
+
+procedure Proc1()
+  new_arg = Int32 0
+end
+
+(* Same name as other procedure *)
+procedure Proc1(arg : Int32)
+  new_arg = Int32 0
+end
+
+
+procedure Proc2()
+  new_arg = Int32 0
+end
+
+(* Same name as procedure *)
+transition Proc2()
+  arg1 = Int32 0;
+  arg2 = Nil {Bool}
+end
+
+
+transition Trans1(arg : Int32)
+  arg1 = Int32 0;
+  arg2 = Nil {Bool}
+end
+
+(* Same name as transition *)
+procedure Trans1()
+  new_arg = Int32 0
+end
+
+transition Trans2()
+  arg1 = Int32 0;
+  arg2 = Nil {Bool}
+end
+
+(* Same name as other transition *)
+transition Trans2(arg : Int32)
+  arg1 = Int32 0;
+  arg2 = Nil {Bool}
+end

--- a/tests/checker/bad/procedure_bad_args.scilla
+++ b/tests/checker/bad/procedure_bad_args.scilla
@@ -1,0 +1,32 @@
+scilla_version 0
+
+library MyLib
+
+contract ProcedureCallBadType ()
+
+field f : Int32 = Int32 42
+
+procedure Proc1(arg1 : Int32, arg2 : (List Bool))
+  new_arg = Int32 0
+end
+
+transition Trans1()
+  arg1 = Int32 0;
+  arg2 = Nil {Bool};
+  (* Wrong number of arguments *)
+  Proc1 arg1
+end
+
+transition Trans2()
+  arg1 = Int32 0;
+  arg2 = Nil {Bool};
+  (* Wrong number of arguments *)
+  Proc1 arg1 arg2 arg1
+end
+
+transition Trans3()
+  arg1 = Int32 0;
+  arg2 = Nil {Bool};
+  (* Wrong number of arguments *)
+  Proc1
+end

--- a/tests/checker/bad/procedure_bad_type.scilla
+++ b/tests/checker/bad/procedure_bad_type.scilla
@@ -1,0 +1,18 @@
+scilla_version 0
+
+library MyLib
+
+contract ProcedureCallBadType ()
+
+field f : Int32 = Int32 42
+
+procedure Proc1(arg1 : Int32, arg2 : (List Bool))
+  new_arg = Int32 0
+end
+
+transition Trans1()
+  arg1 = Int32 0;
+  arg2 = Nil {Bool};
+  (* Wrong type of arguments *)
+  Proc1 arg2 arg1
+end

--- a/tests/checker/bad/procedure_env.scilla
+++ b/tests/checker/bad/procedure_env.scilla
@@ -1,0 +1,27 @@
+scilla_version 0
+
+library MyLib
+
+contract ProcedureBadEnv ()
+
+field f : Int32 = Int32 0
+
+procedure Proc1(a : Int32)
+  (* Legal *)
+  s = _sender;
+  (* Legal *)
+  am = _amount;
+  (* Illegal *)
+  t = _tag;
+  (* Legal *)
+  fs <- f;
+  (* Legal *)
+  b = a;
+  (* Illegal *)
+  c = d
+end
+
+transition Trans1()
+  d = Int32 42;
+  Proc1 d
+end

--- a/tests/checker/bad/procedure_map_arg.scilla
+++ b/tests/checker/bad/procedure_map_arg.scilla
@@ -1,0 +1,21 @@
+scilla_version 0
+
+library MyLib
+
+contract ProcedureCallBadType ()
+
+field m : Map Int32 ByStr20 = Emp Int32 ByStr20
+
+(* Map arguments to procedures not allowed *)
+procedure Proc1(map : Map Int32 ByStr20)
+  new_arg = Int32 0
+end
+
+transition Trans1()
+  Proc1 m
+end
+
+transition Trans1()
+  map <- m;
+  Proc1 map
+end

--- a/tests/checker/bad/procedures_name_clash.scilla
+++ b/tests/checker/bad/procedures_name_clash.scilla
@@ -1,0 +1,32 @@
+scilla_version 0
+
+library MyLib
+
+contract ProcedureCallBadType ()
+
+field f : Int32 = Int32 42
+
+procedure Proc1(arg1 : Int32, arg2 : (List Bool))
+  new_arg = Int32 0
+end
+
+transition Trans1()
+  arg1 = Int32 0;
+  arg2 = Nil {Bool};
+  (* Wrong number of arguments *)
+  Proc1 arg1
+end
+
+transition Trans2()
+  arg1 = Int32 0;
+  arg2 = Nil {Bool};
+  (* Wrong number of arguments *)
+  Proc1 arg1 arg2 arg1
+end
+
+transition Trans3()
+  arg1 = Int32 0;
+  arg2 = Nil {Bool};
+  (* Wrong number of arguments *)
+  Proc1
+end

--- a/tests/checker/bad/recursive_procedure.scilla
+++ b/tests/checker/bad/recursive_procedure.scilla
@@ -1,0 +1,12 @@
+scilla_version 0
+
+library MyLib
+
+contract RecursiveProcedure ()
+
+procedure RecursiveProc(arg : Int32)
+  new_arg = Int32 0;
+  (* Recursive procedures not allowed *)
+  RecursiveProc new_arg
+end
+  

--- a/tests/checker/good/TestCheckerSuccess.ml
+++ b/tests/checker/good/TestCheckerSuccess.ml
@@ -84,6 +84,8 @@ module CheckerTests = TestUtil.DiffBasedTests(
       "TestLibNS4.scillib";
       "libdiamond2.scilla";
       "map-inplace-update-with-_sender.scilla";
+(*      "backward_definition_procedure.scilla";
+        "global_scope_procedures.scilla"; *)
     ]
     let exit_code : Unix.process_status = WEXITED 0
   end)
@@ -97,6 +99,7 @@ module ShogiTests = TestUtil.DiffBasedTests(
     let additional_libdirs = [[ "contracts"; "shogi_lib"]]
     let tests = [
       "shogi.scilla";
+(*    "shogi_proc.scilla"; *)
     ]
     let exit_code : Unix.process_status = WEXITED 0
   end)

--- a/tests/checker/good/backward_definition_procedure.scilla
+++ b/tests/checker/good/backward_definition_procedure.scilla
@@ -1,0 +1,24 @@
+scilla_version 0
+
+library MyLib
+
+contract BackwardDefinitionProcedure ()
+
+field tmp : Int32 = Int32 0
+
+procedure Proc1(arg : Bool)
+  match arg with
+  | True =>
+    a = Int32 1;
+    tmp := a
+  | False =>
+    a = Int32 42;
+    tmp := a
+  end
+end
+
+procedure Proc2 (arg : Int32)
+  new_arg = True;
+  (* Allowed *)
+  Proc1 new_arg
+end

--- a/tests/checker/good/global_scope_procedures.scilla
+++ b/tests/checker/good/global_scope_procedures.scilla
@@ -1,0 +1,23 @@
+scilla_version 0
+
+library MyLib
+
+contract GlobalScopeProcedure ()
+
+field tmp : Int32 = Int32 0
+
+transition MyTrans()
+  new_arg = True;
+  Proc1 new_arg
+end
+
+procedure Proc1(arg : Bool)
+  match arg with
+  | True =>
+    a = Int32 1;
+    tmp := a
+  | False =>
+    a = Int32 42;
+    tmp := a
+  end
+end

--- a/tests/checker/good/gold/backward_definition_procedure.scilla.gold
+++ b/tests/checker/good/gold/backward_definition_procedure.scilla.gold
@@ -1,0 +1,20 @@
+{
+  "errors": [
+    {
+      "error_message":
+        "Type error(s) in contract BackwardDefinitionProcedure:\n",
+      "start_location": {
+        "file": "checker/good/backward_definition_procedure.scilla",
+        "line": 5,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Procedure calls are not supported yet.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/checker/good/gold/global_scope_procedures.scilla.gold
+++ b/tests/checker/good/gold/global_scope_procedures.scilla.gold
@@ -1,0 +1,19 @@
+{
+  "errors": [
+    {
+      "error_message": "Type error(s) in contract GlobalScopeProcedure:\n",
+      "start_location": {
+        "file": "checker/good/global_scope_procedures.scilla",
+        "line": 5,
+        "column": 10
+      },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    },
+    {
+      "error_message": "Procedure calls are not supported yet.",
+      "start_location": { "file": "", "line": 0, "column": 0 },
+      "end_location": { "file": "", "line": 0, "column": 0 }
+    }
+  ],
+  "warnings": []
+}

--- a/tests/contracts/shogi_proc.scilla
+++ b/tests/contracts/shogi_proc.scilla
@@ -1,0 +1,826 @@
+scilla_version 0
+
+(* Import library rather than use contract library *)
+(* to test that types are available *)
+import ShogiLib BoolUtils ListUtils
+
+library Shogi
+
+let move_east =
+  fun (square : Square) =>
+    let one = Uint32 1 in
+    match square with
+    | Square row column =>
+      let new_column = builtin add column one in
+      Square row new_column
+    end
+
+let move_southeast =
+  fun (square : Square) =>
+    let one = Uint32 1 in
+    match square with
+    | Square row column =>
+      let new_column = builtin add column one in
+      let new_row = builtin sub row one in
+      Square new_row new_column
+    end
+
+let move_south =
+  fun (square : Square) =>
+    let one = Uint32 1 in
+    match square with
+    | Square row column =>
+      let new_row = builtin sub row one in
+      Square new_row column
+    end
+
+let move_southwest =
+  fun (square : Square) =>
+    let one = Uint32 1 in
+    match square with
+    | Square row column =>
+      let new_column = builtin sub column one in
+      let new_row = builtin sub row one in
+      Square new_row new_column
+    end
+
+let move_west =
+  fun (square : Square) =>
+    let one = Uint32 1 in
+    match square with
+    | Square row column =>
+      let new_column = builtin sub column one in
+      Square row new_column
+    end
+
+let move_northwest =
+  fun (square : Square) =>
+    let one = Uint32 1 in
+    match square with
+    | Square row column =>
+      let new_column = builtin sub column one in
+      let new_row = builtin add row one in
+      Square new_row new_column
+    end
+
+let move_north =
+  fun (square : Square) =>
+    let one = Uint32 1 in
+    match square with
+    | Square row column =>
+      let new_row = builtin add row one in
+      Square new_row column
+    end
+
+let move_northeast =
+  fun (square : Square) =>
+    let one = Uint32 1 in
+    match square with
+    | Square row column =>
+      let new_column = builtin add column one in
+      let new_row = builtin add row one in
+      Square new_row new_column
+    end
+
+let move_one_square =
+  fun (square : Square) =>
+  fun (direction : Direction) =>
+    match direction with
+    | East      =>
+      move_east square
+    | SouthEast => 
+      move_southeast square
+    | South     => 
+      move_south square
+    | SouthWest => 
+      move_southwest square
+    | West      => 
+      move_west square
+    | NorthWest => 
+      move_northwest square
+    | North     => 
+      move_north square
+    | NorthEast =>
+      move_northeast square
+    end
+
+let generate_path =
+  fun (origin : Square) =>
+  fun (direction : Direction) =>
+  fun (distance : Uint32) =>
+    (* Convert to nat in order to perform recursion *)
+    let distance_as_nat = builtin to_nat distance in
+    let init = Nil {Square} in
+    let folder = @nat_fold (List Square) in
+    let f =
+      fun (acc : (List Square)) =>
+      fun (count : Nat) =>
+        let last_square =
+          match acc with
+          | Cons s _ => s
+          | Nil      => origin
+          end in
+        (* Check if we have moved off the board *)
+        let off_the_board =
+          match last_square with
+          | Square row column =>
+            let zero = Uint32 0 in
+            let ten = Uint32 10 in
+            let too_far_east = builtin eq zero column in
+            let too_far_west = builtin eq ten column in
+            let too_far_south = builtin eq zero row in
+            let too_far_north = builtin eq ten row in
+            let colum_fail = orb too_far_east too_far_west in
+            let row_fail = orb too_far_north too_far_south in
+            orb colum_fail row_fail
+          end in
+        (* If we have gone off off the board we don't add to the path *)
+        match off_the_board with
+        | True => acc
+        | False => 
+          let next_square = move_one_square last_square direction in
+          Cons {Square} next_square acc
+        end in
+      folder f init distance_as_nat
+        
+let king_path =
+  fun (square : Square) =>
+  fun (direction : Direction) =>
+    let one = Uint32 1 in
+    generate_path square direction one
+    
+let gold_path =
+  fun (square : Square) =>
+  fun (direction : Direction) =>
+  fun (player_1_in_turn : Bool) =>
+    match player_1_in_turn with
+    | True =>
+      (* Attacking northwards *)
+      match direction with
+      | SouthWest => 
+        Nil {Square}
+      | SouthEast =>
+        Nil {Square}
+      | _ =>
+        let one = Uint32 1 in
+        generate_path square direction one
+      end
+    | False =>
+      (* Attacking southwards *)
+      match direction with
+      | NorthWest => 
+        Nil {Square}
+      | NorthEast =>
+        Nil {Square}
+      | _ =>
+        let one = Uint32 1 in
+        generate_path square direction one
+      end
+    end
+      
+let silver_path =
+  fun (square : Square) =>
+  fun (direction : Direction) =>
+  fun (player_1_in_turn : Bool) =>
+    match player_1_in_turn with
+    | True =>
+      (* Attacking northwards *)
+      match direction with
+      | South => 
+        Nil {Square}
+      | East =>
+        Nil {Square}
+      | West =>
+        Nil {Square}
+      | _ =>
+        let one = Uint32 1 in
+        generate_path square direction one
+      end
+    | False =>
+      (* Attacking southwards *)
+      match direction with
+      | North => 
+        Nil {Square}
+      | East =>
+        Nil {Square}
+      | West =>
+        Nil {Square}
+      | _ =>
+        let one = Uint32 1 in
+        generate_path square direction one
+      end
+    end
+          
+let knight_path =
+  fun (square : Square) =>
+  fun (direction : Direction) =>
+  fun (player_1_in_turn : Bool) =>
+    (* Knights jump, so path only contains final square *)
+    match player_1_in_turn with
+    | True =>
+      (* Attacking northwards *)
+      let north = North in
+      match direction with
+      | NorthEast => 
+        let nil_path = Nil {Square} in
+        let first_square = move_one_square square north in
+        let final_square = move_one_square first_square direction in
+        Cons {Square} final_square nil_path
+      | NorthWest =>
+        let nil_path = Nil {Square} in
+        let first_square = move_one_square square north in
+        let final_square = move_one_square first_square direction in
+        Cons {Square} final_square nil_path
+      | _ =>
+        Nil {Square}
+      end
+    | False =>
+      (* Attacking southwards *)
+      let south = South in
+      match direction with
+      | SouthEast => 
+        let nil_path = Nil {Square} in
+        let first_square = move_one_square square south in
+        let final_square = move_one_square first_square direction in
+        Cons {Square} final_square nil_path
+      | SouthWest =>
+        let nil_path = Nil {Square} in
+        let first_square = move_one_square square south in
+        let final_square = move_one_square first_square direction in
+        Cons {Square} final_square nil_path
+      | _ =>
+        Nil {Square}
+      end
+    end
+
+let pawn_path =
+  fun (square : Square) =>
+  fun (direction : Direction) =>
+  fun (player_1_in_turn : Bool) =>
+    match player_1_in_turn with
+    | True =>
+      (* Attacking northwards *)
+      match direction with
+      | North =>
+        let one = Uint32 1 in
+        generate_path square direction one
+      | _ =>
+        Nil {Square}
+      end
+    | False =>
+      (* Attacking southwards *)
+      match direction with
+      | South => 
+        let one = Uint32 1 in
+        generate_path square direction one
+      | _ =>
+        Nil {Square}
+      end
+    end
+
+let lance_path =
+  fun (square : Square) =>
+  fun (direction : Direction) =>
+  fun (distance : Uint32) =>
+  fun (player_1_in_turn : Bool) =>
+    match player_1_in_turn with
+    | True =>
+      (* Attacking northwards *)
+      match direction with
+      | North => 
+        generate_path square direction distance
+      | _ =>
+        Nil {Square}
+      end
+    | False =>
+      (* Attacking southwards *)
+      match direction with
+      | South => 
+        generate_path square direction distance
+      | _ =>
+        Nil {Square}
+      end
+    end
+
+(* Bishops and rooks *)
+let officer_path =
+  fun (square : Square) =>
+  fun (direction : Direction) =>
+  fun (distance : Uint32) =>
+    generate_path square direction distance
+
+(* Generate the path of squares that a piece moves along *)
+(* The first element of the resulting list of squares is the target square of the move *)
+(* An empty list indicates an illegal move *)
+let movement_path =
+  fun (square : Square) =>
+  fun (piece : Piece) =>
+  fun (promotion_status : PromotionStatus) =>
+  fun (direction : Direction) =>
+  fun (distance : Uint32) =>
+  (* Determines whether attacking northwards or southwards *)
+  fun (player_1_in_turn : Bool) =>
+    match piece with
+    | King =>
+      (* Check distance *)
+      let one = Uint32 1 in
+      let distance_is_one = builtin eq one distance in
+      match distance_is_one with
+      | True => 
+        king_path square direction
+      | False =>
+        Nil {Square}
+      end
+    | GoldGeneral =>
+      (* Check distance *)
+      let one = Uint32 1 in
+      let distance_is_one = builtin eq one distance in
+      match distance_is_one with
+      | True => 
+        gold_path square direction player_1_in_turn
+      | False =>
+        Nil {Square}
+      end
+    | SilverGeneral =>
+      let one = Uint32 1 in
+      let distance_is_one = builtin eq one distance in
+      match distance_is_one with
+      | True => 
+        match promotion_status with
+        | Promoted =>
+          (* Promoted to gold general *)
+          gold_path square direction player_1_in_turn
+        | NotPromoted =>
+          silver_path square direction player_1_in_turn
+        end
+      | False =>
+        Nil {Square}
+      end
+    | Knight =>
+      match promotion_status with
+      | Promoted =>
+        (* Promoted to gold general *)
+        let one = Uint32 1 in
+        let distance_is_one = builtin eq one distance in
+        match distance_is_one with
+        | True => 
+          gold_path square direction player_1_in_turn
+        | False =>
+          Nil {Square}
+        end
+      | NotPromoted =>
+        (* Knights move 2 squares forward and 1 to the side. *)
+        (* Represented as NorthEast/NorthWest (for player 1) by 2 squares *)
+        let two = Uint32 2 in
+        let distance_is_two = builtin eq two distance in
+        match distance_is_two with
+        | True => 
+          knight_path square direction player_1_in_turn
+        | False =>
+          Nil {Square}
+        end
+      end
+    | Pawn =>
+      let one = Uint32 1 in
+      let distance_is_one = builtin eq one distance in
+      match distance_is_one with
+      | True => 
+        match promotion_status with
+        | Promoted =>
+          (* Promoted to gold general *)
+          gold_path square direction player_1_in_turn
+        | NotPromoted =>
+          pawn_path square direction player_1_in_turn
+        end
+      | False =>
+        Nil {Square}
+      end
+    | Lance =>
+      match promotion_status with
+      | Promoted =>
+        (* Promoted to gold general *)
+        let one = Uint32 1 in
+        let distance_is_one = builtin eq one distance in
+        match distance_is_one with
+        | True => 
+          gold_path square direction player_1_in_turn
+        | False =>
+          Nil {Square}
+        end
+      | NotPromoted =>
+        (* Lances move any number of squares forward. *)
+        let zero = Uint32 0 in
+        let distance_is_greater_that_zero = builtin lt zero distance in
+        match distance_is_greater_that_zero with
+        | True =>
+          lance_path square direction distance player_1_in_turn
+        | False =>
+          Nil {Square}
+        end
+      end
+    | Bishop =>
+      match direction with
+      | SouthEast =>
+        officer_path square direction distance 
+      | SouthWest =>
+        officer_path square direction distance 
+      | NorthEast =>
+        officer_path square direction distance 
+      | NorthWest =>
+        officer_path square direction distance 
+      | _ =>
+        (* Only allowed if bishop is promoted *)
+        match promotion_status with
+        | NotPromoted =>
+          Nil {Square}
+        | Promoted =>
+          let one = Uint32 1 in
+          let distance_is_one = builtin eq one distance in
+          match distance_is_one with
+          | True => 
+            officer_path square direction one
+          | False =>
+            Nil {Square}
+          end
+        end
+      end
+    | Rook =>
+      match direction with
+      | South =>
+        officer_path square direction distance 
+      | West =>
+        officer_path square direction distance 
+      | East =>
+        officer_path square direction distance 
+      | North =>
+        officer_path square direction distance 
+      | _ =>
+        (* Only allowed if rook is promoted *)
+        match promotion_status with
+        | NotPromoted =>
+          Nil {Square}
+        | Promoted =>
+          let one = Uint32 1 in
+          let distance_is_one = builtin eq one distance in
+          match distance_is_one with
+          | True => 
+            officer_path square direction one
+          | False =>
+            Nil {Square}
+          end
+        end
+      end
+    end
+
+let perform_promotion =
+  fun (promote : Bool) =>
+  fun (promotion_status : PromotionStatus) =>
+  fun (origin_row : Uint32) =>
+  fun (target_row : Uint32) =>
+  fun (player_1_in_turn : Bool) =>
+    match promote with
+    | False =>
+      (* No attempt made to promote *)
+      Some {PromotionStatus} promotion_status
+    | True =>
+      (* Attempt to promote *)
+      match promotion_status with
+      | Promoted =>
+        (* Cannot promote an already promoted piece *)
+        None {PromotionStatus}
+      | NotPromoted =>
+        (* Check that move happened in opponent territory *)
+        match player_1_in_turn with
+        | True =>
+          (* Move must occur on row 7 or higher *)
+          let seven = Uint32 7 in
+          (* Attacking northwards *)
+          let origin_not_in_opponent_territory = builtin lt origin_row seven in
+          let target_not_in_opponent_territory = builtin lt target_row seven in
+          let not_in_opponent_territory = andb origin_not_in_opponent_territory target_not_in_opponent_territory in
+          match not_in_opponent_territory with
+          | True =>
+            (* Cannot promote piece outside of opponent territory *)
+            None {PromotionStatus}
+          | False =>
+            Some {PromotionStatus} promoted
+          end
+        | False =>
+          (* Move must occur on row 3 or lower *)
+          let three = Uint32 3 in
+          (* Attacking northwards *)
+          let origin_not_in_opponent_territory = builtin lt three origin_row in
+          let target_not_in_opponent_territory = builtin lt three target_row in
+          let not_in_opponent_territory = andb origin_not_in_opponent_territory target_not_in_opponent_territory in
+          match not_in_opponent_territory with
+          | True =>
+            (* Cannot promote piece outside of opponent territory *)
+            None {PromotionStatus}
+          | False =>
+            Some {PromotionStatus} promoted
+          end
+        end
+      end
+    end
+
+type Error =
+| GameOver
+| PlayingOutOfTurn
+| IllegalAction
+| InternalError
+
+let game_is_over = GameOver
+let playing_out_of_turn = PlayingOutOfTurn
+let illegal_action = IllegalAction
+let internal_error = InternalError
+
+(* Error events *)
+let mk_error_event =
+  fun (err : Error) =>
+  let err_code = 
+    match err with
+    | GameOver         => Int32 -1
+    | PlayingOutOfTurn => Int32 -2
+    | IllegalAction    => Int32 -3
+    | InternalError    => Int32 -999
+    end in
+  { _eventname : "ShogiError" ; err_code : err_code }
+
+let mk_winner_event =
+  fun (current_player : ByStr20) =>
+  fun (player1 : ByStr20) =>
+  fun (player2 : ByStr20) =>
+    let current_player_is_one = builtin eq player1 current_player in
+    let player_no = 
+      match current_player_is_one with
+      | True => Uint32 1
+      | False => Uint32 2
+    end in
+  { _eventname : "ShogiWinner" ; winner : player_no }
+
+let get_next_player =
+  fun (current_player : ByStr20) =>
+  fun (player1 : ByStr20) =>
+  fun (player2 : ByStr20) =>
+    let current_player_is_one = builtin eq player1 current_player in
+    match current_player_is_one with
+    | True => player2
+    | False => player1
+    end
+
+contract ShogiProc
+(
+player1 : ByStr20,
+player2 : ByStr20
+)
+
+(* Initialize board *)
+field board : Map Uint32 (Map Uint32 SquareContents) = initial_board player1 player2
+field captured_pieces : Map ByStr20 (Map Uint32 Uint32) = init_captured_pieces player1 player2
+(* player1 moves first *)
+(* player_in_turn = None indicates that game is over *)
+field player_in_turn : Option ByStr20 = Some {ByStr20} player1
+field winner : Option ByStr20 = None {ByStr20}
+
+procedure InternalErrorEvent ()
+  none_player = None {ByStr20};
+  player_in_turn := none_player;
+  err = internal_error;
+  e = mk_error_event err;
+  event e
+end
+
+procedure IllegalActionEvent ()
+  err = illegal_action;
+  e = mk_error_event err;
+  event e
+end
+
+procedure Winner (winning_player : ByStr20)
+  none = None {ByStr20};
+  player_in_turn := none;
+  some_winner = Some {ByStr20} winning_player;
+  winner := some_winner
+end
+
+procedure Resign (current_player : ByStr20)
+  opponent = get_next_player current_player player1 player2;
+  Winner opponent
+end
+
+procedure PlacePiece (piece : Piece, square : Square)
+  (* Place a captured piece on the board *)
+  (* Check that player has captured piece available *)
+  piece_no = piece_to_int piece;
+  capture_count <- captured_pieces[_sender][piece_no];
+  match capture_count with
+  | None => 
+    (* This should not happen *)
+    ErrorEvent
+  | Some count =>
+    zero = Uint32 0;
+    has_pieces = builtin lt zero count;
+    match has_pieces with
+    | False =>
+      IllegalActionEvent
+    | True =>
+      (* Check if desired square is available *)
+      match square with
+      | Square row column =>
+        target_square_content <- board[row][column];
+        match target_square_content with
+        | Some Free =>
+          (* Remove from captured pieces, and place on board *)
+          one = Uint32 1;
+          new_count = builtin sub count one;
+          captured_pieces[_sender][piece_no] := new_count;
+          new_contents = Occupied piece not_promoted _sender;
+          board[row][column] := new_contents
+        | _ =>
+          (* Square does not exist on board, or square is occupied *)
+          IllegalActionEvent
+        end
+      end
+    end
+  end
+end
+
+procedure PerformMoveAndPromote (
+  promote : Bool,
+  promotion_status : PromotionStatus,
+  row : Uint32,
+  column: Uint32,
+  target_row : Uint32,
+  target_column : Uint32,
+  player_1_moves : Bool
+  )
+  new_promotion_status_opt = perform_promotion promote promotion_status row target_row player_1_moves;
+  match new_promotion_status_opt with
+  | None =>
+    (* Illegal promotion *)
+    IllegalActionEvent
+  | Some new_promotion_status =>
+    (* Move piece *)
+    (* Source square is no longer occupied *)
+    board[row][column] := free;
+    (* Update target square *)
+    new_contents_at_target = Occupied piece new_promotion_status current_player;
+    board[target_row][target_column] := new_contents_at_target
+  end
+end
+
+procedure MovePiece (current_player : ByStr20, square : Square, direction : Direction, distance : Uint32, promote : Bool)
+  match square with
+  | Square row column =>
+    (* Find the contents of the origin square *)
+    contents <- board[row][column];
+    match contents with
+    | Some (Occupied piece promotion_status owner) =>
+      correct_owner = builtin eq owner current_player;
+      match correct_owner with
+      | False =>
+        IllegalActionEvent
+      | True =>
+        player_1_moves = builtin eq current_player player1;
+        path = movement_path square piece promotion_status direction distance player_1_moves;
+        match path with
+        | Nil => 
+          IllegalActionEvent
+        | Cons (Square target_row target_column) intervening_squares =>
+          (* Piece is allowed to move as requested. Check for blocking pieces.  *)
+          board_tmp <- board;
+          blocked_path = 
+          let exister = @list_exists Square in
+          let occupied_predicate =
+            fun (square : Square) =>
+              match square with
+              | Square row column =>
+                let row_contents = builtin get board_tmp row in
+                match row_contents with
+                | None         => False (* Should never happen *)
+                | Some row_map =>
+                  let contents = builtin get row_map column in
+                  match contents with
+                  | Some (Occupied _ _ _) => True
+                  | Some  Free            => False
+                  | None                  => False (* Should never happen *)
+                  end
+                end
+              end in
+            exister occupied_predicate intervening_squares;
+          match blocked_path with
+          | True => 
+            IllegalActionEvent
+          | False =>
+            (* Check contents of target square *)
+            contents_at_target <- board[target_row][target_column];
+            match contents_at_target with
+            | None =>
+              (* Moving off the board *)
+              IllegalActionEvent
+            | Some  Free  => 
+              (* No piece captured *)
+              (* Check promotion, and move *)
+              PerformMoveAndPromote promote promotion_status row column target_row target_column player_1_moves
+            | Some (Occupied captured_piece _ captured_owner) =>
+              (* Target square is occupied. Check ownership *)
+              captured_owner_is_current_player = builtin eq captured_owner current_player;
+              match captured_owner_is_current_player with
+              | True =>
+                (* Target square is blocked *)
+                IllegalActionEvent
+              | False =>
+                (* Opponent piece captured. *)
+                (* Check promotion part of move *)
+                PerformMoveAndPromote promote promotion_status row column target_row target_column player_1_moves;
+                (* Check if captured piece is the king *)
+                match captured_piece with
+                | King =>
+                  (* Game is won *)
+                  Winner current_player
+                | _ =>
+                  (* Add captured piece to list of captured pieces *)
+                  captured_piece_no = piece_to_int captured_piece;
+                  captured_count_opt <- captured_pieces[current_player][captured_piece_no];
+                  match captured_count_opt with
+                  | None =>
+                    InternalErrorEvent
+                  | Some count =>
+                    one = Uint32 1;
+                    new_captured_count = builtin add count one;
+                    captured_pieces[current_player][captured_piece_no] := new_captured_count
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    | _ =>
+      (* No piece on the square, or square does not exist *)
+      IllegalActionEvent
+    end
+  end
+end
+
+(* Execute Move action by sending message to execute PlayerAction transition *)
+transition MoveAction (
+  row : Uint32,
+  column : Uint32,
+  direction : Direction,
+  distance : Uint32,
+  promote : Bool
+  )
+  square = Square row column;
+  zero = Uint128 0;
+  move = Move square direction distance promote;
+  msg = { _tag : "PlayerAction"; _amount : zero; _recipient : _this_address; action : move};
+  nil_msg = Nil {Message};
+  msgs = Cons {Message} msg nil_msg;
+  send msgs
+end
+
+(* Execute player action *)
+transition PlayerAction (action : Action)
+  false = False;
+  true = True;
+  current_player_opt <- player_in_turn;
+  match current_player_opt with
+  | None =>
+    (* Game is over *)
+    err = game_is_over;
+    e = mk_error_event err;
+    event e
+  | Some current_player =>
+    correct_player = builtin eq _sender current_player;
+    match correct_player with
+    | False =>
+      err = playing_out_of_turn;
+      e = mk_error_event err;
+      event e
+    | True =>
+      match action with
+      (* Resign and award game to opponent *)
+      | Resign =>
+        Resign current_player
+      | Place piece square =>
+        PlacePiece piece square
+      | Move square direction distance promote =>
+        MovePiece current_player square direction distance
+      end
+    end;
+    (* Check if a winner has been found *)
+    win <- winner;
+    match win with
+    | Some player =>
+      (* Game is over. Announce winner *)
+      e = mk_winner_event player player1 player2;
+      event e
+    | None =>
+      (* Set player_in_turn to opposite player *)
+      next_player = get_next_player current_player player1 player2;
+      next_player_opt = Some {ByStr20} next_player;
+      player_in_turn := next_player_opt
+    end
+  end
+end

--- a/tests/runner/Testcontracts.ml
+++ b/tests/runner/Testcontracts.ml
@@ -31,7 +31,7 @@ let fail_code : Caml.Unix.process_status = WEXITED 1
  * Build tests to invoke scilla-runner with the right arguments, for
  * multiple test cases, each suffixed with _i up to _n (both inclusive)
  *)
-let rec build_contract_tests env name exit_code i n add_additional_lib =
+let rec build_contract_tests env name exit_code i n additional_libs =
   if i > n
     then []
   else
@@ -60,9 +60,9 @@ let rec build_contract_tests env name exit_code i n add_additional_lib =
               "-jsonerrors";
               "-iblockchain" ; dir ^/ "blockchain_" ^ istr ^. "json"] in
         let args' =
-          if add_additional_lib
-          then ["-libdir"; contract_dir ^/ name ^ "_lib"] @ args_tmp
-          else args_tmp
+          List.fold_right additional_libs ~init:args_tmp
+            ~f:(fun lib_name cur_args ->
+                "-libdir" :: (contract_dir ^/ lib_name) :: cur_args)
         in
         let args =
           if disable_validate_json then "-disable-validate-json" :: args' else args'
@@ -90,9 +90,9 @@ let rec build_contract_tests env name exit_code i n add_additional_lib =
        * Both should succeed. *)
       if exit_code = succ_code
       then
-        (test true) :: (test false) :: (build_contract_tests env name exit_code (i+1) n add_additional_lib)
+        (test true) :: (test false) :: (build_contract_tests env name exit_code (i+1) n additional_libs)
       else
-        (test false) :: (build_contract_tests env name exit_code (i+1) n add_additional_lib)
+        (test false) :: (build_contract_tests env name exit_code (i+1) n additional_libs)
 
 let build_contract_init_test env exit_code name is_library =
   name ^ "_init" >::
@@ -163,38 +163,39 @@ let build_misc_tests env =
 let add_tests env =
   "contract_tests" >:::[
     "these_tests_must_SUCCEED" >:::[
-      "crowdfunding" >:::(build_contract_tests env "crowdfunding" succ_code 1 6 false);
+      "crowdfunding" >:::(build_contract_tests env "crowdfunding" succ_code 1 6 []);
       "crowdfunding_init" >:(build_contract_init_test env succ_code "crowdfunding" false);
-      "zil-game" >:::(build_contract_tests env "zil-game" succ_code 1 9 false);
+      "zil-game" >:::(build_contract_tests env "zil-game" succ_code 1 9 []);
       "zil-game_init" >:(build_contract_init_test env succ_code "zil-game" false);
       "creationtest_init" >:(build_contract_init_test env succ_code "creationtest" false);
       "testlib2_init" >:(build_contract_init_test env succ_code "TestLib2" true);
-      "cfinvoke" >:::(build_contract_tests env "cfinvoke" succ_code 1 4 false);
-      "ping" >:::(build_contract_tests env "ping" succ_code 0 3 false);
-      "pong" >:::(build_contract_tests env "pong" succ_code 0 3 false);
-      "helloWorld" >:::(build_contract_tests env "helloWorld" succ_code 1 4 false);
-      "auction" >:::(build_contract_tests env "auction" succ_code 1 8 false);
-      "mappair" >:::(build_contract_tests env "mappair" succ_code 1 7 false);
-      "bookstore" >:::(build_contract_tests env "bookstore" succ_code 1 10 false);
-      "nonfungible-token" >:::(build_contract_tests env "nonfungible-token" succ_code 1 12 false);
-      "nonfungible-token" >:::(build_contract_tests env "nonfungible-token" succ_code 21 27 false);
-      "schnorr" >:::(build_contract_tests env "schnorr" succ_code 1 3 false);
-      "ecdsa" >:::(build_contract_tests env "ecdsa" succ_code 1 4 false);
-      "empty_contract" >::: (build_contract_tests env "empty" succ_code 1 1 false);
-      "fungible-token" >:::(build_contract_tests env "fungible-token" succ_code 0 8 false);
-      "inplace-map" >:::(build_contract_tests env "inplace-map" succ_code 1 14 false);
-      "wallet" >:::(build_contract_tests env "wallet" succ_code 1 11 false);
-      "one_msg_test" >::: (build_contract_tests env "one-msg" succ_code 1 1 false);
-      "one_msg1_test" >::: (build_contract_tests env "one-msg1" succ_code 1 1 false);
-      "simple-dex" >:::(build_contract_tests env "simple-dex" succ_code 1 8 false);
-      "shogi" >::: (build_contract_tests env "shogi" succ_code 1 4 true);
-      "map_key_test" >::: (build_contract_tests env "map_key_test" succ_code 1 1 false);
+      "cfinvoke" >:::(build_contract_tests env "cfinvoke" succ_code 1 4 []);
+      "ping" >:::(build_contract_tests env "ping" succ_code 0 3 []);
+      "pong" >:::(build_contract_tests env "pong" succ_code 0 3 []);
+      "helloWorld" >:::(build_contract_tests env "helloWorld" succ_code 1 4 []);
+      "auction" >:::(build_contract_tests env "auction" succ_code 1 8 []);
+      "mappair" >:::(build_contract_tests env "mappair" succ_code 1 7 []);
+      "bookstore" >:::(build_contract_tests env "bookstore" succ_code 1 10 []);
+      "nonfungible-token" >:::(build_contract_tests env "nonfungible-token" succ_code 1 12 []);
+      "nonfungible-token" >:::(build_contract_tests env "nonfungible-token" succ_code 21 27 []);
+      "schnorr" >:::(build_contract_tests env "schnorr" succ_code 1 3 []);
+      "ecdsa" >:::(build_contract_tests env "ecdsa" succ_code 1 4 []);
+      "empty_contract" >::: (build_contract_tests env "empty" succ_code 1 1 []);
+      "fungible-token" >:::(build_contract_tests env "fungible-token" succ_code 0 8 []);
+      "inplace-map" >:::(build_contract_tests env "inplace-map" succ_code 1 14 []);
+      "wallet" >:::(build_contract_tests env "wallet" succ_code 1 11 []);
+      "one_msg_test" >::: (build_contract_tests env "one-msg" succ_code 1 1 []);
+      "one_msg1_test" >::: (build_contract_tests env "one-msg1" succ_code 1 1 []);
+      "simple-dex" >:::(build_contract_tests env "simple-dex" succ_code 1 8 []);
+      "shogi" >::: (build_contract_tests env "shogi" succ_code 1 4 ["shogi_lib"]);
+(*    "shogi_proc" >::: (build_contract_tests env "shogi_proc" succ_code 1 4 ["shogi_lib"]); *)
+      "map_key_test" >::: (build_contract_tests env "map_key_test" succ_code 1 1 []);
     ];
     "these_tests_must_FAIL" >:::[
-      "helloWorld_f" >:::(build_contract_tests env "helloWorld" fail_code 5 11 false);
-      "mappair" >:::(build_contract_tests env "mappair" fail_code 8 8 false);
-      "mappair" >:::(build_contract_tests env "mappair" fail_code 12 14 false);
-      "multiple_msgs_test" >::: (build_contract_tests env "multiple-msgs" fail_code 1 1 true);
+      "helloWorld_f" >:::(build_contract_tests env "helloWorld" fail_code 5 11 []);
+      "mappair" >:::(build_contract_tests env "mappair" fail_code 8 8 []);
+      "mappair" >:::(build_contract_tests env "mappair" fail_code 12 14 []);
+      "multiple_msgs_test" >::: (build_contract_tests env "multiple-msgs" fail_code 1 1 []);
       "testlib1_init" >:(build_contract_init_test env fail_code "0x565556789012345678901234567890123456abcd" true);
     ];
     "misc_tests" >::: build_misc_tests env;

--- a/tests/runner/shogi_proc/blockchain_1.json
+++ b/tests/runner/shogi_proc/blockchain_1.json
@@ -1,0 +1,1 @@
+[ { "vname": "BLOCKNUMBER", "type": "BNum", "value": "100" } ]

--- a/tests/runner/shogi_proc/blockchain_2.json
+++ b/tests/runner/shogi_proc/blockchain_2.json
@@ -1,0 +1,1 @@
+[ { "vname": "BLOCKNUMBER", "type": "BNum", "value": "100" } ]

--- a/tests/runner/shogi_proc/blockchain_3.json
+++ b/tests/runner/shogi_proc/blockchain_3.json
@@ -1,0 +1,1 @@
+[ { "vname": "BLOCKNUMBER", "type": "BNum", "value": "100" } ]

--- a/tests/runner/shogi_proc/blockchain_4.json
+++ b/tests/runner/shogi_proc/blockchain_4.json
@@ -1,0 +1,1 @@
+[ { "vname": "BLOCKNUMBER", "type": "BNum", "value": "100" } ]

--- a/tests/runner/shogi_proc/init.json
+++ b/tests/runner/shogi_proc/init.json
@@ -1,0 +1,27 @@
+[
+    { 
+        "vname" : "_scilla_version",
+        "type" : "Uint32",
+        "value" : "0"
+    },
+    {
+        "vname" : "_this_address",
+        "type" : "ByStr20",
+        "value" : "0xabfeccdc9012345678901234567890f777567890"
+    },
+    {
+        "vname" : "player1",
+        "type" : "ByStr20",
+        "value" : "0x1234567890123456789012345678906784567890"
+    },
+    {
+        "vname" : "player2",
+        "type" : "ByStr20",
+        "value" : "0xabcdeabcde123456786782345678901234567890"
+    },
+    {
+        "vname" : "_creation_block",
+        "type" : "BNum",
+        "value" : "1"
+    }
+]

--- a/tests/runner/shogi_proc/message_1.json
+++ b/tests/runner/shogi_proc/message_1.json
@@ -1,0 +1,36 @@
+{
+    "_tag": "PlayerAction",
+    "_amount": "0",
+    "_sender" : "0x1234567890123456789012345678906784567890",
+    "params": [
+        {
+            "vname" : "action",
+            "type"  : "Action",
+            "value" : {
+                "constructor" : "Move",
+                "argtypes"    : [],
+                "arguments"   : [
+                    {
+                        "constructor" : "Square",
+                        "argtypes" : [],
+                        "arguments" : [
+                            "1",
+                            "1"
+                        ]
+                    },
+                    {
+                        "constructor" : "North",
+                        "argtypes"    : [],
+                        "arguments"   : []
+                    },
+                    "3",
+                    {
+                        "constructor" : "False",
+                        "argtypes"    : [],
+                        "arguments"   : []
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/runner/shogi_proc/message_2.json
+++ b/tests/runner/shogi_proc/message_2.json
@@ -1,0 +1,36 @@
+{
+    "_tag": "PlayerAction",
+    "_amount": "0",
+    "_sender" : "0x1234567890123456789012345678906784567890",
+    "params": [
+        {
+            "vname" : "action",
+            "type"  : "Action",
+            "value" : {
+                "constructor" : "Move",
+                "argtypes"    : [],
+                "arguments"   : [
+                    {
+                        "constructor" : "Square",
+                        "argtypes" : [],
+                        "arguments" : [
+                            "1",
+                            "1"
+                        ]
+                    },
+                    {
+                        "constructor" : "North",
+                        "argtypes"    : [],
+                        "arguments"   : []
+                    },
+                    "3",
+                    {
+                        "constructor" : "False",
+                        "argtypes"    : [],
+                        "arguments"   : []
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/runner/shogi_proc/message_3.json
+++ b/tests/runner/shogi_proc/message_3.json
@@ -1,0 +1,36 @@
+{
+    "_tag": "PlayerAction",
+    "_amount": "0",
+    "_sender" : "0x1234567890123456789012345678906784567890",
+    "params": [
+        {
+            "vname" : "action",
+            "type"  : "Action",
+            "value" : {
+                "constructor" : "Move",
+                "argtypes"    : [],
+                "arguments"   : [
+                    {
+                        "constructor" : "Square",
+                        "argtypes" : [],
+                        "arguments" : [
+                            "1",
+                            "1"
+                        ]
+                    },
+                    {
+                        "constructor" : "North",
+                        "argtypes"    : [],
+                        "arguments"   : []
+                    },
+                    "3",
+                    {
+                        "constructor" : "False",
+                        "argtypes"    : [],
+                        "arguments"   : []
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/runner/shogi_proc/message_4.json
+++ b/tests/runner/shogi_proc/message_4.json
@@ -1,0 +1,42 @@
+{
+    "_tag": "MoveAction",
+    "_amount": "0",
+    "_sender" : "0x1234567890123456789012345678906784567890",
+    "params": [
+        {
+            "vname" : "row",
+            "type"  : "Uint32",
+            "value" : "1"
+        },
+        {
+            "vname" : "column",
+            "type"  : "Uint32",
+            "value" : "1"
+        },
+        {
+            "vname" : "direction",
+            "type"  : "Direction",
+            "value" :
+            {
+                "constructor" : "North",
+                "argtypes"    : [],
+                "arguments"   : []
+            }
+        },
+        {
+            "vname" : "distance",
+            "type"  : "Uint32",
+            "value" : "3"
+        },
+        {
+            "vname" : "promote",
+            "type"  : "Bool",
+            "value" :
+            {
+                "constructor" : "False",
+                "argtypes"    : [],
+                "arguments"   : []
+            }
+        }
+    ]
+}

--- a/tests/runner/shogi_proc/output_1.json
+++ b/tests/runner/shogi_proc/output_1.json
@@ -1,0 +1,99 @@
+{
+  "scilla_major_version": "0",
+  "gas_remaining": "5401",
+  "_accepted": "false",
+  "message": null,
+  "states": [
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+      "vname": "player_in_turn",
+      "type": "Option (ByStr20)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr20" ],
+        "arguments": [ "0xabcdeabcde123456786782345678901234567890" ]
+      }
+    },
+    {
+      "vname": "board",
+      "type": "Map (Uint32) (Map (Uint32) (SquareContents))",
+      "value": [
+        {
+          "key": "1",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Free",
+                "argtypes": [],
+                "arguments": []
+              }
+            }
+          ]
+        },
+        {
+          "key": "3",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Free",
+                "argtypes": [],
+                "arguments": []
+              }
+            }
+          ]
+        },
+        {
+          "key": "4",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Occupied",
+                "argtypes": [],
+                "arguments": [
+                  { "constructor": "Lance", "argtypes": [], "arguments": [] },
+                  {
+                    "constructor": "NotPromoted",
+                    "argtypes": [],
+                    "arguments": []
+                  },
+                  "0x1234567890123456789012345678906784567890"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "key": "2",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Free",
+                "argtypes": [],
+                "arguments": []
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "vname": "captured_pieces",
+      "type": "Map (ByStr20) (Map (Uint32) (Uint32))",
+      "value": []
+    },
+    {
+      "vname": "winner",
+      "type": "Option (ByStr20)",
+      "value": {
+        "constructor": "None",
+        "argtypes": [ "ByStr20" ],
+        "arguments": []
+      }
+    }
+  ],
+  "events": []
+}

--- a/tests/runner/shogi_proc/output_2.json
+++ b/tests/runner/shogi_proc/output_2.json
@@ -1,0 +1,112 @@
+{
+  "scilla_major_version": "0",
+  "gas_remaining": "5362",
+  "_accepted": "false",
+  "message": null,
+  "states": [
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+      "vname": "player_in_turn",
+      "type": "Option (ByStr20)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr20" ],
+        "arguments": [ "0xabcdeabcde123456786782345678901234567890" ]
+      }
+    },
+    {
+      "vname": "board",
+      "type": "Map (Uint32) (Map (Uint32) (SquareContents))",
+      "value": [
+        {
+          "key": "1",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Occupied",
+                "argtypes": [],
+                "arguments": [
+                  { "constructor": "Rook", "argtypes": [], "arguments": [] },
+                  {
+                    "constructor": "NotPromoted",
+                    "argtypes": [],
+                    "arguments": []
+                  },
+                  "0x1234567890123456789012345678906784567890"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "key": "3",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Occupied",
+                "argtypes": [],
+                "arguments": [
+                  { "constructor": "Pawn", "argtypes": [], "arguments": [] },
+                  {
+                    "constructor": "NotPromoted",
+                    "argtypes": [],
+                    "arguments": []
+                  },
+                  "0x1234567890123456789012345678906784567890"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "key": "4",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Free",
+                "argtypes": [],
+                "arguments": []
+              }
+            }
+          ]
+        },
+        {
+          "key": "2",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Free",
+                "argtypes": [],
+                "arguments": []
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "vname": "captured_pieces",
+      "type": "Map (ByStr20) (Map (Uint32) (Uint32))",
+      "value": []
+    },
+    {
+      "vname": "winner",
+      "type": "Option (ByStr20)",
+      "value": {
+        "constructor": "None",
+        "argtypes": [ "ByStr20" ],
+        "arguments": []
+      }
+    }
+  ],
+  "events": [
+    {
+      "_eventname": "ShogiError",
+      "params": [ { "vname": "err_code", "type": "Int32", "value": "-3" } ]
+    }
+  ]
+}

--- a/tests/runner/shogi_proc/output_3.json
+++ b/tests/runner/shogi_proc/output_3.json
@@ -1,0 +1,104 @@
+{
+  "scilla_major_version": "0",
+  "gas_remaining": "5313",
+  "_accepted": "false",
+  "message": null,
+  "states": [
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+      "vname": "player_in_turn",
+      "type": "Option (ByStr20)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr20" ],
+        "arguments": [ "0xabcdeabcde123456786782345678901234567890" ]
+      }
+    },
+    {
+      "vname": "board",
+      "type": "Map (Uint32) (Map (Uint32) (SquareContents))",
+      "value": [
+        {
+          "key": "1",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Free",
+                "argtypes": [],
+                "arguments": []
+              }
+            }
+          ]
+        },
+        {
+          "key": "3",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Free",
+                "argtypes": [],
+                "arguments": []
+              }
+            }
+          ]
+        },
+        {
+          "key": "4",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Occupied",
+                "argtypes": [],
+                "arguments": [
+                  { "constructor": "Rook", "argtypes": [], "arguments": [] },
+                  {
+                    "constructor": "NotPromoted",
+                    "argtypes": [],
+                    "arguments": []
+                  },
+                  "0x1234567890123456789012345678906784567890"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "key": "2",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Free",
+                "argtypes": [],
+                "arguments": []
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "vname": "captured_pieces",
+      "type": "Map (ByStr20) (Map (Uint32) (Uint32))",
+      "value": [
+        {
+          "key": "0x1234567890123456789012345678906784567890",
+          "val": [ { "key": "6", "val": "1" } ]
+        }
+      ]
+    },
+    {
+      "vname": "winner",
+      "type": "Option (ByStr20)",
+      "value": {
+        "constructor": "None",
+        "argtypes": [ "ByStr20" ],
+        "arguments": []
+      }
+    }
+  ],
+  "events": []
+}

--- a/tests/runner/shogi_proc/output_4.json
+++ b/tests/runner/shogi_proc/output_4.json
@@ -1,0 +1,136 @@
+{
+  "scilla_major_version": "0",
+  "gas_remaining": "5983",
+  "_accepted": "false",
+  "message": {
+    "_tag": "PlayerAction",
+    "_amount": "0",
+    "_recipient": "0xabfeccdc9012345678901234567890f777567890",
+    "params": [
+      {
+        "vname": "action",
+        "type": "Action",
+        "value": {
+          "constructor": "Move",
+          "argtypes": [],
+          "arguments": [
+            {
+              "constructor": "Square",
+              "argtypes": [],
+              "arguments": [ "1", "1" ]
+            },
+            { "constructor": "North", "argtypes": [], "arguments": [] },
+            "3",
+            { "constructor": "False", "argtypes": [], "arguments": [] }
+          ]
+        }
+      }
+    ]
+  },
+  "states": [
+    { "vname": "_balance", "type": "Uint128", "value": "0" },
+    {
+      "vname": "board",
+      "type": "Map (Uint32) (Map (Uint32) (SquareContents))",
+      "value": [
+        {
+          "key": "1",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Occupied",
+                "argtypes": [],
+                "arguments": [
+                  { "constructor": "Rook", "argtypes": [], "arguments": [] },
+                  {
+                    "constructor": "NotPromoted",
+                    "argtypes": [],
+                    "arguments": []
+                  },
+                  "0x1234567890123456789012345678906784567890"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "key": "3",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Free",
+                "argtypes": [],
+                "arguments": []
+              }
+            }
+          ]
+        },
+        {
+          "key": "4",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Occupied",
+                "argtypes": [],
+                "arguments": [
+                  { "constructor": "Pawn", "argtypes": [], "arguments": [] },
+                  {
+                    "constructor": "NotPromoted",
+                    "argtypes": [],
+                    "arguments": []
+                  },
+                  "0xabcdeabcde123456786782345678901234567890"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "key": "2",
+          "val": [
+            {
+              "key": "1",
+              "val": {
+                "constructor": "Free",
+                "argtypes": [],
+                "arguments": []
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "vname": "captured_pieces",
+      "type": "Map (ByStr20) (Map (Uint32) (Uint32))",
+      "value": [
+        {
+          "key": "0x1234567890123456789012345678906784567890",
+          "val": [ { "key": "6", "val": "0" } ]
+        }
+      ]
+    },
+    {
+      "vname": "player_in_turn",
+      "type": "Option (ByStr20)",
+      "value": {
+        "constructor": "Some",
+        "argtypes": [ "ByStr20" ],
+        "arguments": [ "0x1234567890123456789012345678906784567890" ]
+      }
+    },
+    {
+      "vname": "winner",
+      "type": "Option (ByStr20)",
+      "value": {
+        "constructor": "None",
+        "argtypes": [ "ByStr20" ],
+        "arguments": []
+      }
+    }
+  ],
+  "events": []
+}

--- a/tests/runner/shogi_proc/state_1.json
+++ b/tests/runner/shogi_proc/state_1.json
@@ -1,0 +1,106 @@
+[
+    { "vname": "_balance",
+      "type": "Uint128",
+      "value": "0" },
+    {
+      "vname": "board",
+      "type": "Map Uint32 (Map Uint32 SquareContents)",
+      "value": [
+          {
+              "key": "1",
+              "val": [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "Lance",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0x1234567890123456789012345678906784567890"
+                          ]
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "2",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {   
+              "key" : "3",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "4",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          }
+      ]
+    },
+    {
+      "vname": "captured_pieces",
+      "type": "Map (ByStr20) (Map (Uint32) (Uint32))",
+      "value": []
+    },
+    { 
+      "vname": "player_in_turn",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "Some",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : [
+                "0x1234567890123456789012345678906784567890"
+            ]
+        }
+    },
+    { 
+      "vname": "winner",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "None",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : []
+        }
+    }
+]

--- a/tests/runner/shogi_proc/state_2.json
+++ b/tests/runner/shogi_proc/state_2.json
@@ -1,0 +1,118 @@
+[
+    { "vname": "_balance",
+      "type": "Uint128",
+      "value": "0" },
+    {
+      "vname": "board",
+      "type": "Map Uint32 (Map Uint32 SquareContents)",
+      "value": [
+          {
+              "key": "1",
+              "val": [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "Rook",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0x1234567890123456789012345678906784567890"
+                          ]
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "2",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {   
+              "key" : "3",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "Pawn",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0x1234567890123456789012345678906784567890"
+                          ]
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "4",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          }
+      ]
+    },
+    {
+      "vname": "captured_pieces",
+      "type": "Map (ByStr20) (Map (Uint32) (Uint32))",
+      "value": []
+    },
+    { 
+      "vname": "player_in_turn",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "Some",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : [
+                "0x1234567890123456789012345678906784567890"
+            ]
+        }
+    },
+    { 
+      "vname": "winner",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "None",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : []
+        }
+    }
+]

--- a/tests/runner/shogi_proc/state_3.json
+++ b/tests/runner/shogi_proc/state_3.json
@@ -1,0 +1,128 @@
+[
+    { "vname": "_balance",
+      "type": "Uint128",
+      "value": "0" },
+    {
+      "vname": "board",
+      "type": "Map Uint32 (Map Uint32 SquareContents)",
+      "value": [
+          {
+              "key": "1",
+              "val": [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "Rook",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0x1234567890123456789012345678906784567890"
+                          ]
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "2",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {   
+              "key" : "3",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "4",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "Pawn",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0xabcdeabcde123456786782345678901234567890"
+                          ]
+                      }
+                  }
+              ]
+          }
+      ]
+    },
+    {
+      "vname": "captured_pieces",
+      "type": "Map (ByStr20) (Map (Uint32) (Uint32))",
+      "value": [
+          {   
+              "key" : "0x1234567890123456789012345678906784567890",
+              "val" : [
+                  {
+                      "key" : "6",
+                      "val" : "0"
+                  }
+              ]
+          }
+      ]
+    },
+    { 
+      "vname": "player_in_turn",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "Some",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : [
+                "0x1234567890123456789012345678906784567890"
+            ]
+        }
+    },
+    { 
+      "vname": "winner",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "None",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : []
+        }
+    }
+]

--- a/tests/runner/shogi_proc/state_4.json
+++ b/tests/runner/shogi_proc/state_4.json
@@ -1,0 +1,128 @@
+[
+    { "vname": "_balance",
+      "type": "Uint128",
+      "value": "0" },
+    {
+      "vname": "board",
+      "type": "Map Uint32 (Map Uint32 SquareContents)",
+      "value": [
+          {
+              "key": "1",
+              "val": [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "Rook",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0x1234567890123456789012345678906784567890"
+                          ]
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "2",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {   
+              "key" : "3",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Free",
+                          "argtypes" : [],
+                          "arguments" : []
+                      }
+                  }
+              ]
+          },
+          {
+              "key" : "4",
+              "val" : [
+                  {
+                      "key" : "1",
+                      "val" : 
+                      {
+                          "constructor" : "Occupied",
+                          "argtypes" : [],
+                          "arguments" : [
+                              {
+                                  "constructor" : "Pawn",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              {
+                                  "constructor" : "NotPromoted",
+                                  "argtypes" : [],
+                                  "arguments" : []
+                              },
+                              "0xabcdeabcde123456786782345678901234567890"
+                          ]
+                      }
+                  }
+              ]
+          }
+      ]
+    },
+    {
+      "vname": "captured_pieces",
+      "type": "Map (ByStr20) (Map (Uint32) (Uint32))",
+      "value": [
+          {   
+              "key" : "0x1234567890123456789012345678906784567890",
+              "val" : [
+                  {
+                      "key" : "6",
+                      "val" : "0"
+                  }
+              ]
+          }
+      ]
+    },
+    { 
+      "vname": "player_in_turn",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "Some",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : [
+                "0x1234567890123456789012345678906784567890"
+            ]
+        }
+    },
+    { 
+      "vname": "winner",
+      "type": "Option ByStr20",
+      "value":
+        {
+            "constructor": "None",
+            "argtypes"   : [ "ByStr20" ],
+            "arguments"  : []
+        }
+    }
+]


### PR DESCRIPTION
* Add procedure keyword to emacs mode

* Bugfix in emacs mode

* Added (negative) tests of recursive procedures

* Updated gold files, and added forward definition test

* Positive scoping tests for procedures

* Bugfix : Allow procedure calls without parameters

* Typechecker tests for procedures

* Name clashes test added

* Added test for map arguments to procedures

* Environment test for procedures

* Added env test to test suite

* Shogi contract with procedures

* Added shogi_proc to interpreter tests